### PR TITLE
商品情報を編集できるようにする実装

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -22,6 +22,21 @@ class ProductsController < ApplicationController
     @product = Product.find(params[:id])
   end
 
+  def edit
+    @product = Product.find(params[:id])
+  end
+
+  def update
+    @product = Product.find(params[:id])
+    @product.update(product_params)
+    if @product.save
+      redirect_to root_path
+    else
+      render :edit
+    end
+  end
+
+
   private
 
   def product_params

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,6 @@
 class ProductsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create]
+  before_action :authenticate_user!, expect: [:index, :show ]
+  before_action :@product = Product.find(params[:id]), only: [:show, :edit, :update ]
 
   def index
     @products = Product.includes(:user).order('created_at DESC')
@@ -19,23 +20,19 @@ class ProductsController < ApplicationController
   end
 
   def show
-    @product = Product.find(params[:id])
   end
 
   def edit
-    @product = Product.find(params[:id])
+    redirect_to root_path if current_user.id != @product.user_id
   end
 
   def update
-    @product = Product.find(params[:id])
-    @product.update(product_params)
     if @product.save
       redirect_to root_path
     else
       render :edit
     end
   end
-
 
   private
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,7 +1,7 @@
 class ProductsController < ApplicationController
-  before_action :authenticate_user!, expect: [:index, :show ]
-  before_action :@product = Product.find(params[:id]), only: [:show, :edit, :update ]
-  before_action :current_user.id != @product.user_id, only: [:edit, :update ]
+  before_action :authenticate_user!, expect: [:index, :show]
+  before_action :select_product, only: [:show, :edit, :update]
+  before_action :contributor_confirmation, only: [:edit, :update]
 
   def index
     @products = Product.includes(:user).order('created_at DESC')
@@ -24,12 +24,11 @@ class ProductsController < ApplicationController
   end
 
   def edit
-    redirect_to root_path
   end
 
   def update
-    if
-      redirect_to root_path
+    if @product.update(product_params)
+      redirect_to product_path(@product)
     else
       render :edit
     end
@@ -40,5 +39,13 @@ class ProductsController < ApplicationController
   def product_params
     params.require(:product).permit(:name, :explain, :category_id, :status_id, :shipping_free_status_id, :prefecture_id,
                                     :scheduled_delivery_id, :price, :image).merge(user_id: current_user.id)
+  end
+
+  def contributor_confirmation
+    redirect_to root_path if current_user.id != @product.user_id
+  end
+
+  def select_product
+    @product = Product.find(params[:id])
   end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,7 @@
 class ProductsController < ApplicationController
   before_action :authenticate_user!, expect: [:index, :show ]
   before_action :@product = Product.find(params[:id]), only: [:show, :edit, :update ]
+  before_action :current_user.id != @product.user_id, only: [:edit, :update ]
 
   def index
     @products = Product.includes(:user).order('created_at DESC')
@@ -23,11 +24,11 @@ class ProductsController < ApplicationController
   end
 
   def edit
-    redirect_to root_path if current_user.id != @product.user_id
+    redirect_to root_path
   end
 
   def update
-    if @product.save
+    if
       redirect_to root_path
     else
       render :edit

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -139,7 +139,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', product_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -7,7 +7,7 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with model: @product, url: products_path, local: true do |f| %>
+    <%= form_with model: @product, local: true do |f| %>
 
     <%= render 'shared/error_messages', model: f.object %>
 

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -7,11 +7,9 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @product, url: products_path, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%= render 'shared/error_messages', model: f.object %>
 
     <%# 商品画像 %>
     <div class="img-upload">
@@ -23,7 +21,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
@@ -33,13 +31,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :explain, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +50,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:status_id, Status.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +71,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_free_status_id, ShippingFreeStatus.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:scheduled_delivery_id, ScheduledDelivery.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +99,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>


### PR DESCRIPTION
# What
商品情報編集機能の実装になります。

# Why
商品情報を編集できるようにするための実装です。


・ログイン状態の出品者は、商品情報編集ページに遷移できる動画

https://gyazo.com/b0f9066024555d550e9f5b36167b462c

・正しく情報を記入すると、商品の情報を編集できる動画

https://gyazo.com/6fae51630f0433836178efdacdca55e8

・入力に問題のある状態では商品の情報は編集できず、エラーメッセージが出力される動画

https://gyazo.com/c03191baf33a400f443623b6e80fa582

・何も編集せずに更新をしても画像無しの商品にならない動画

https://gyazo.com/344f3ddcaf0238a8f294f6c30de35c31

・ログイン状態のユーザーであっても、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画

https://gyazo.com/b65d55b2e01b80a807376c385935b954

・ログアウト状態のユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移する動画

https://gyazo.com/3e38b9e4cc07e19da844b8446893e18f

・商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（画像に関しては、表示されない状態で良い）

https://gyazo.com/99ddf556442ff5a6d8af0a5eaf3e88ec